### PR TITLE
assert

### DIFF
--- a/pyiron_dft/bandstructure.py
+++ b/pyiron_dft/bandstructure.py
@@ -32,7 +32,8 @@ class BandPath(object):
         self.q_dist = np.zeros(n_points)
 
     def _generate_points(self):
-        assert(self.bs_obj.structure is not None)
+        if not (self.bs_obj.structure is not None):
+            raise AssertionError()
         spl_distances = list()
         for i, sp in enumerate(self.special_points):
             if i < len(self.special_points) - 1:

--- a/pyiron_dft/generic.py
+++ b/pyiron_dft/generic.py
@@ -71,7 +71,8 @@ class GenericDFTJob(AtomisticGenericJob):
 
     @fix_spin_constraint.setter
     def fix_spin_constraint(self, boolean):
-        assert isinstance(boolean, bool)
+        if not isinstance(boolean, bool):
+            raise AssertionError()
         self._generic_input['fix_spin_constraint'] = boolean
 
     @property
@@ -80,7 +81,8 @@ class GenericDFTJob(AtomisticGenericJob):
 
     @fix_symmetry.setter
     def fix_symmetry(self, boolean):
-        assert isinstance(boolean, bool)
+        if not isinstance(boolean, bool):
+            raise AssertionError()
         self._generic_input['fix_symmetry'] = boolean
 
     def set_kmesh_density(self, kspace_per_in_ang=0.10):

--- a/pyiron_dft/murnaghan_dft.py
+++ b/pyiron_dft/murnaghan_dft.py
@@ -43,8 +43,10 @@ class MurnaghanDFT(Murnaghan):
         Returns: Structure with equilibrium volume
 
         """
-        assert iteration_step == -1
-        assert (self.structure is not None)
+        if not (iteration_step == -1):
+            raise AssertionError()
+        if not (self.structure is not None):
+            raise AssertionError()
         snapshot = self.structure.copy()
         old_vol = snapshot.get_volume()
         new_vol = self["output/equilibrium_volume"]

--- a/pyiron_dft/waves/dos.py
+++ b/pyiron_dft/waves/dos.py
@@ -76,10 +76,9 @@ class Dos(object):
             import matplotlib.pylab as plt
         except ImportError:
             import matplotlib.pyplot as plt
-        try:
-            if not (self.es_obj.grand_dos_matrix is not None):
-                raise NoResolvedDosError("Can not plot the orbital resolved dos since resolved dos values are not"
-                                         " available")
+        if not (self.es_obj.grand_dos_matrix is not None):
+            raise NoResolvedDosError("Can not plot the orbital resolved dos since resolved dos values are not"
+                                     " available")
         plot = self.plot_total_dos()
         for key, val in self.orbital_dict.items():
             r_dos = self.get_orbital_resolved_dos(val)

--- a/pyiron_dft/waves/dos.py
+++ b/pyiron_dft/waves/dos.py
@@ -77,10 +77,9 @@ class Dos(object):
         except ImportError:
             import matplotlib.pyplot as plt
         try:
-            assert(self.es_obj.grand_dos_matrix is not None)
-        except AssertionError:
-            raise NoResolvedDosError("Can not plot the orbital resolved dos since resolved dos values are not"
-                                     " available")
+            if not (self.es_obj.grand_dos_matrix is not None):
+                raise NoResolvedDosError("Can not plot the orbital resolved dos since resolved dos values are not"
+                                         " available")
         plot = self.plot_total_dos()
         for key, val in self.orbital_dict.items():
             r_dos = self.get_orbital_resolved_dos(val)
@@ -100,9 +99,7 @@ class Dos(object):
             numpy.ndarray instance containing the required dos
 
         """
-        try:
-            assert (self.es_obj.grand_dos_matrix is not None)
-        except AssertionError:
+        if not (self.es_obj.grand_dos_matrix is not None):
             raise NoResolvedDosError("Can not get the spin resolved dos since resolved dos values are not"
                                      " available")
 
@@ -147,9 +144,7 @@ class Dos(object):
             numpy.ndarray instance containing the required dos
 
         """
-        try:
-            assert (self.es_obj.grand_dos_matrix is not None)
-        except AssertionError:
+        if not (self.es_obj.grand_dos_matrix is not None):
             raise NoResolvedDosError("Can not get the spatially resolved dos since resolved dos values are not"
                                      " available")
         grand_sum = np.sum(self.es_obj.grand_dos_matrix)
@@ -193,9 +188,7 @@ class Dos(object):
             numpy.ndaray instance containing the required dos
 
         """
-        try:
-            assert(self.es_obj.grand_dos_matrix is not None)
-        except AssertionError:
+        if not (self.es_obj.grand_dos_matrix is not None):
             raise NoResolvedDosError("Can not get the orbital resolved dos since resolved dos values are not"
                                      " available")
         grand_sum = np.sum(self.es_obj.grand_dos_matrix)
@@ -239,9 +232,7 @@ class Dos(object):
         Returns:
             numpy.ndaray instance containing the required dos
         """
-        try:
-            assert(self.es_obj.grand_dos_matrix is not None)
-        except AssertionError:
+        if not (self.es_obj.grand_dos_matrix is not None):
             raise NoResolvedDosError("Can not get the resolved dos since resolved dos values are not"
                                      " available")
         grand_sum = np.sum(self.es_obj.grand_dos_matrix)

--- a/pyiron_dft/waves/electronic.py
+++ b/pyiron_dft/waves/electronic.py
@@ -373,9 +373,7 @@ class ElectronicStructure(object):
         bool: Tells if the given system is metallic or not. The Fermi level crosses bands in the cas of metals but is
               present in the band gap in the case of semi-conductors.
         """
-        try:
-            assert(self._efermi is not None)
-        except AssertionError:
+        if not (self._efermi is not None):
             raise ValueError("e_fermi has to be set before you can determine if the system is metallic or not")
         fermi_crossed = False
         _, n_bands = np.shape(self.eigenvalue_matrix)
@@ -560,9 +558,7 @@ class ElectronicStructure(object):
             Spin resolved dos (numpy.ndarray instance)
 
         """
-        try:
-            assert(len(self.dos_energies) > 0)
-        except AssertionError:
+        if not (len(self.dos_energies) > 0):
             raise ValueError("The DOS is not computed/saved for this vasp run")
         return self.dos_densities[spin_indices]
 


### PR DESCRIPTION
It was discovered that some projects used assert to enforce interface constraints. However, assert is removed with compiling to optimised byte code (python -o producing *.pyo files). This caused various protections to be removed. The use of assert is also considered as general bad practice in OpenStack codebases.